### PR TITLE
Added GET /log endpoint 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,7 @@ require (
 )
 
 require (
-	github.com/ctessum/geom v0.2.12 // indirect
-	github.com/ctessum/polyclip-go v1.1.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
-	github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 // indirect
-	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
@@ -24,5 +20,4 @@ require (
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	gonum.org/v1/gonum v0.9.3 // indirect
 )

--- a/scd/scd.go
+++ b/scd/scd.go
@@ -8,15 +8,20 @@ import (
 type StrategicDeconfliction interface {
 	Inject(request dss.PutOirRequest) (dss.OperationalIntent, error)
 	FetchOir(id string) (dss.OperationalIntent, error)
-	FetchVersion(id string) (Version)
+	FetchVersion(id string) Version
+	FetchLog(timestamp_start string, timestamp_end string) Log
 }
 
 type InterussDeconflictor struct {
 }
 
 type Version struct {
-	SystemId string   `json:"system_id"`
-	Version  string   `json:"version"`
+	SystemId string `json:"system_id"`
+	Version  string `json:"version"`
+}
+
+type Log struct {
+	Content string `json:"content"`
 }
 
 func (d InterussDeconflictor) Inject(request dss.PutOirRequest) (dss.OperationalIntent, error) {
@@ -42,7 +47,10 @@ func (d InterussDeconflictor) FetchOir(id string) (dss.OperationalIntent, error)
 	return oir, err
 }
 
+func (d InterussDeconflictor) FetchVersion(id string) Version {
+	return Version{id, "1.0"}
+}
 
-func (d InterussDeconflictor) FetchVersion(id string) (Version) {
-		return Version{id,"1.0"}
+func (d InterussDeconflictor) FetchLog(timestamp_start string, timestamp_end string) Log {
+	return Log{"Lorem ipsum dolor sit amet"}
 }


### PR DESCRIPTION
As required in ASTM-3548, USS must implement a endpoint for log fetching to be used for audition purposes.

- GET /log implementation to return a mocked response.