### PR TITLE
Added fluentd as log driver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  scd_provider:
+    container_name: scd_provider
+    build:
+      context: .
+    restart: on-failure
+    logging:
+      driver: fluentd
+      options:
+        tag: scd-provider-api
+    ports:
+      - '9091:9091'
+    expose:
+      - '9091'


### PR DESCRIPTION
Implemented docker compose with fluentd as logging driver using **scd-provider-api** tag.

How to test:
```
docker compose up --build

```